### PR TITLE
feat: add notice card to invited speakers section

### DIFF
--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -1,4 +1,11 @@
-import { Calendar, Mail, MapPin, ExternalLink, FileText } from "lucide-react";
+import {
+  Calendar,
+  Mail,
+  MapPin,
+  ExternalLink,
+  FileText,
+  Info,
+} from "lucide-react";
 import { SiSlack } from "react-icons/si";
 import { Link, useLocation } from "react-router";
 import { useEffect } from "react";
@@ -241,6 +248,14 @@ function Home() {
           <h2 className="text-2xl sm:text-3xl tracking-tighter">
             Invited Speakers
           </h2>
+        </div>
+        <div className="flex items-start gap-4 rounded-lg border bg-card p-6">
+          <Info className="h-6 w-6 shrink-0 text-primary" />
+          <p>
+            The list of invited speakers is not yet finalized. Some speakers
+            have given tentative confirmation, and additional speakers may be
+            announced in the future. Please check back for updates.
+          </p>
         </div>
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {programData.invitedSpeakers.map((speaker, index) => (


### PR DESCRIPTION
## Summary
- Add an info notice card to the Invited Speakers section
- The card informs visitors that the speaker list is tentative and may be updated
- Uses Info icon from lucide-react to draw attention to the notice

## Test plan
- [x] Verify the notice card appears at the top of the Invited Speakers section
- [x] Check that the Info icon displays correctly
- [x] Confirm styling matches the existing card design (Latest News style)
- [x] Test both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)