### PR TITLE
feat: update workshop program schedule

### DIFF
--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -35,99 +35,75 @@
           "slides": ""
         },
         {
-          "time": "08:40 - 09:10",
+          "time": "08:40 - 09:20",
           "session": "Invited Talk 1",
           "presenter": "Robert Geirhos",
           "slides": ""
         },
         {
-          "time": "09:10 - 09:40",
+          "time": "09:20 - 10:00",
           "session": "Invited Talk 2",
           "presenter": "Aditi Raghunathan",
           "slides": ""
         },
         {
-          "time": "09:40 - 10:10",
+          "time": "10:00 - 10:40",
           "session": "Invited Talk 3",
           "presenter": "Matt Deitke",
           "slides": ""
         },
         {
-          "time": "10:10 - 10:20",
+          "time": "10:40 - 11:00",
           "session": "Short Break",
           "presenter": "",
           "slides": ""
         },
         {
-          "time": "10:20 - 10:50",
+          "time": "11:00 - 11:40",
           "session": "Invited Talk 4",
           "presenter": "Kristen Grauman",
           "slides": ""
         },
         {
-          "time": "10:50 - 11:20",
+          "time": "11:40 - 12:20",
           "session": "Invited Talk 5",
           "presenter": "Yuki M. Asano",
           "slides": ""
         },
         {
-          "time": "11:20 - 11:30",
-          "session": "Short Break",
-          "presenter": "",
-          "slides": ""
-        },
-        {
-          "time": "11:30 - 12:00",
-          "session": "Panel session (1-5)",
-          "presenter": "",
-          "slides": ""
-        },
-        {
-          "time": "12:00 - 13:30",
+          "time": "12:20 - 13:30",
           "session": "Lunch break / poster session (invite-only)",
           "presenter": "",
           "slides": ""
         },
         {
-          "time": "13:30 - 14:00",
+          "time": "13:30 - 14:10",
           "session": "Invited Talk 6",
           "presenter": "Andrea Vedaldi",
           "slides": ""
         },
         {
-          "time": "14:00 - 14:30",
+          "time": "14:10 - 14:50",
           "session": "Invited Talk 7",
           "presenter": "Alexei A. Efros",
           "slides": ""
         },
         {
-          "time": "14:30 - 15:00",
+          "time": "14:50 - 15:10",
           "session": "Coffee break",
           "presenter": "",
           "slides": ""
         },
         {
-          "time": "15:00 - 15:30",
+          "time": "15:10 - 15:50",
           "session": "Invited Talk 8",
           "presenter": "Jamie Shotton",
           "slides": ""
         },
         {
-          "time": "15:30 - 16:00",
+          "time": "15:50 - 16:30",
           "session": "Invited Talk 9",
           "presenter": "Kaiming He",
-          "slides": ""
-        },
-        {
-          "time": "16:00 - 16:10",
-          "session": "Short Break",
-          "presenter": "",
-          "slides": ""
-        },
-        {
-          "time": "16:10 - 16:40",
-          "session": "Panel session (6-9)",
-          "presenter": "",
           "slides": ""
         },
         {


### PR DESCRIPTION
## Summary
- Extended invited talks from 30 minutes to 40 minutes each
- Removed panel sessions (previously at 11:30-12:00 and 16:10-16:40)
- Extended short break to 20 minutes (10:40-11:00)
- Adjusted lunch break start time to 12:20
- Shortened coffee break to 20 minutes (14:50-15:10)

## Changes
This update allows for more in-depth presentations and better time management throughout the workshop day.

## Test plan
- [ ] Verify schedule displays correctly on the website
- [ ] Confirm all time slots are properly aligned
- [ ] Ensure total workshop duration fits within venue availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)