### PR TITLE
feat: add invited talk titles to program

### DIFF
--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -227,7 +227,16 @@ function Home() {
               {scheduleData.workshopProgram.day1.schedule.map((item, index) => (
                 <TableRow key={index}>
                   <TableCell className="font-medium">{item.time}</TableCell>
-                  <TableCell>{item.session}</TableCell>
+                  <TableCell>
+                    <div className="space-y-1">
+                      <div>{item.session}</div>
+                      {item.title && (
+                        <div className="text-sm text-muted-foreground italic">
+                          {item.title}
+                        </div>
+                      )}
+                    </div>
+                  </TableCell>
                   <TableCell>{item.presenter || ""}</TableCell>
                   <TableCell className="hidden md:table-cell">
                     {item.slides ? (
@@ -281,8 +290,6 @@ function Home() {
                       loading="lazy"
                     />
                   </div>
-                  {/* <h3 className="font-semibold">{speaker.title}</h3>
-                  <p className="text-sm text-muted-foreground">{speaker.bio}</p> */}
                 </div>
               </CardContent>
               <CardFooter>

--- a/src/data/program.json
+++ b/src/data/program.json
@@ -38,7 +38,7 @@
       "name": "Yuki M. Asano",
       "affiliation": "University of Technology Nuremberg",
       "photo": "/program/yuki.asano-512x512.jpg",
-      "title": "",
+      "title": "Learning from moving, Generalising from speaking",
       "bio": "",
       "website": "https://yukimasano.github.io/"
     },
@@ -46,7 +46,7 @@
       "name": "Andrea Vedaldi",
       "affiliation": "University of Oxford / Meta",
       "photo": "/program/andrea.vedaldi-512x512.jpg",
-      "title": "",
+      "title": "Building a 3D Foundation for Spatial AI",
       "bio": "",
       "website": "https://www.robots.ox.ac.uk/~vedaldi/"
     },
@@ -62,7 +62,7 @@
       "name": "Alex Kendall",
       "affiliation": "Wayve",
       "photo": "/program/alex.kendall-512x512.jpg",
-      "title": "",
+      "title": "Frontier challenges to bring general purpose driving AI to 10M cars",
       "bio": "",
       "website": "https://alexgkendall.com/"
     },

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -38,18 +38,21 @@
           "time": "08:40 - 09:20",
           "session": "Invited Talk 1",
           "presenter": "Robert Geirhos",
+          "title": "",
           "slides": ""
         },
         {
           "time": "09:20 - 10:00",
           "session": "Invited Talk 2",
           "presenter": "Aditi Raghunathan",
+          "title": "",
           "slides": ""
         },
         {
           "time": "10:00 - 10:40",
           "session": "Invited Talk 3",
           "presenter": "Matt Deitke",
+          "title": "",
           "slides": ""
         },
         {
@@ -62,12 +65,14 @@
           "time": "11:00 - 11:40",
           "session": "Invited Talk 4",
           "presenter": "Kristen Grauman",
+          "title": "",
           "slides": ""
         },
         {
           "time": "11:40 - 12:20",
           "session": "Invited Talk 5",
           "presenter": "Yuki M. Asano",
+          "title": "Learning from moving, Generalising from speaking",
           "slides": ""
         },
         {
@@ -80,12 +85,14 @@
           "time": "13:30 - 14:10",
           "session": "Invited Talk 6",
           "presenter": "Andrea Vedaldi",
+          "title": "Building a 3D Foundation for Spatial AI",
           "slides": ""
         },
         {
           "time": "14:10 - 14:50",
           "session": "Invited Talk 7",
           "presenter": "Alexei A. Efros",
+          "title": "",
           "slides": ""
         },
         {
@@ -98,12 +105,14 @@
           "time": "15:10 - 15:50",
           "session": "Invited Talk 8",
           "presenter": "Alex Kendall",
+          "title": "Frontier challenges to bring general purpose driving AI to 10M cars",
           "slides": ""
         },
         {
           "time": "15:50 - 16:30",
           "session": "Invited Talk 9",
           "presenter": "Kaiming He",
+          "title": "",
           "slides": ""
         },
         {


### PR DESCRIPTION
## Summary
- Add title field to schedule data structure for invited talks
- Display talk titles in workshop program table (shown in italic below session names)
- Remove commented code from Invited Speakers section

## Added Titles
- Yuki M. Asano: "Learning from moving, Generalising from speaking"
- Andrea Vedaldi: "Building a 3D Foundation for Spatial AI"
- Alex Kendall: "Frontier challenges to bring general purpose driving AI to 10M cars"

## Test plan
- [x] Check that titles display correctly in workshop program table
- [x] Verify titles are shown in italic formatting
- [x] Confirm Invited Speakers section displays correctly without title field

🤖 Generated with [Claude Code](https://claude.com/claude-code)