### PR TITLE
feat: add talk titles to program and schedule

### DIFF
--- a/src/data/program.json
+++ b/src/data/program.json
@@ -6,7 +6,7 @@
       "name": "Robert Geirhos",
       "affiliation": "Google DeepMind",
       "photo": "/program/robert.geirhos-512x512.jpg",
-      "title": "",
+      "title": "Are generative video models the path towards solving visual intelligence?",
       "bio": "",
       "website": "https://robertgeirhos.com/"
     },

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -30,15 +30,16 @@
       "schedule": [
         {
           "time": "08:30 - 08:40",
-          "session": "Opening Remarks",
+          "session": "Organizer Talk & Opening Remarks",
           "presenter": "Hirokatsu Kataoka",
+          "title": "Visual General Intelligence: Vision Research Toward the AGI Era",
           "slides": ""
         },
         {
           "time": "08:40 - 09:20",
           "session": "Invited Talk 1",
           "presenter": "Robert Geirhos",
-          "title": "",
+          "title": "Are generative video models the path towards solving visual intelligence?",
           "slides": ""
         },
         {


### PR DESCRIPTION
## Summary
- Add Robert Geirhos invited talk title: "Are generative video models the path towards solving visual intelligence?"
- Add Hirokatsu Kataoka organizer talk title: "Visual General Intelligence: Vision Research Toward the AGI Era"
- Update opening session name to "Organizer Talk & Opening Remarks"

## Test plan
- [x] Verify JSON files are valid
- [x] Confirm title additions match speaker information

🤖 Generated with [Claude Code](https://claude.com/claude-code)