### PR TITLE
feat: remove Kaiming He from invited speakers and schedule

### DIFF
--- a/src/data/program.json
+++ b/src/data/program.json
@@ -65,14 +65,6 @@
       "title": "Frontier challenges to bring general purpose driving AI to 10M cars",
       "bio": "",
       "website": "https://alexgkendall.com/"
-    },
-    {
-      "name": "Kaiming He",
-      "affiliation": "Massachusetts Institute of Technology / Google DeepMind",
-      "photo": "/program/kaiming.he-512x512.jpg",
-      "title": "",
-      "bio": "",
-      "website": "https://people.csail.mit.edu/kaiming/"
     }
   ],
   "acceptedPapers": {

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -110,14 +110,7 @@
           "slides": ""
         },
         {
-          "time": "15:50 - 16:30",
-          "session": "Invited Talk 9",
-          "presenter": "Kaiming He",
-          "title": "",
-          "slides": ""
-        },
-        {
-          "time": "16:40 - 16:50",
+          "time": "15:50 - 16:00",
           "session": "Closing remarks",
           "presenter": "",
           "slides": ""


### PR DESCRIPTION
## Issue URL

NA

## Change overview

Remove Kaiming He from the invited speakers list and adjust the workshop schedule. The closing remarks have been moved from 16:40-16:50 to 15:50-16:00 to follow immediately after Invited Talk 8 (Alex Kendall).

## How to test

NA

## Note for reviewers

NA