### PR TITLE
feat: update event date to 2026 and add discussion time

### DIFF
--- a/src/data/home.json
+++ b/src/data/home.json
@@ -3,7 +3,7 @@
   "tagline": "-Vision Research Toward the AGI Era-",
   "subtitle": "CVPR 2026 Workshop",
   "eventInfo": {
-    "date": "June 3, 2025, 8:30 AM - 4:50 PM",
+    "date": "June 3, 2026, 8:30 AM - 4:50 PM",
     "location": "Colorado Convention Center - Room 703"
   },
   "overview": {

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -114,6 +114,12 @@
           "session": "Closing remarks",
           "presenter": "",
           "slides": ""
+        },
+        {
+          "time": "16:00 - 16:50",
+          "session": "Discussion time",
+          "presenter": "",
+          "slides": ""
         }
       ]
     },


### PR DESCRIPTION
## Issue URL

NA

## Change overview

- Update event date from June 3, 2025 to June 3, 2026
- Add discussion time slot (16:00 - 16:50) after closing remarks

## How to test

NA

## Note for reviewers

NA