### PR TITLE
feat: add invited poster session with board assignments

### DIFF
--- a/docs/posters.csv
+++ b/docs/posters.csv
@@ -1,0 +1,19 @@
+Board,Paper,Authors,URL
+1-left,Theory of Space: Can Foundation Models Construct Spatial Beliefs through Active Exploration?,"Pingyue Zhang, Zihan Huang, Yue Wang, Jieyu Zhang, Letian Xue, Zihan Wang, Qineng Wang, Keshigeyan Chandrasegaran, Ruohan Zhang, Yejin Choi, Ranjay Krishna, Jiajun Wu, Li Fei-Fei, Manling Li",https://arxiv.org/abs/2602.07055
+1-right,"Unique Lives, Shared World: Learning from Single-Life Videos","Tengda Han, Sayna Ebrahimi, Dilara Gokay, Li Yang Ku, Maks Ovsjanikov, Iva Babukova, Daniel Zoran, Viorica Patraucean, Joao Carreira, Andrew Zisserman, Dima Damen",https://arxiv.org/abs/2512.04085
+2-left,Learning to See Through a Baby's Eyes: Early Visual Diets Enable Robust Visual Intelligence in Humans and Machines,"Yusen Cai, Qing Lin, Bhargava Satya Nunna, Mengmi Zhang",https://arxiv.org/abs/2511.14440
+2-right,From None to All: Self-Supervised 3D Reconstruction via Novel View Synthesis,"Ranran Huang, Weixun Luo, Ye Mao, Krystian Mikolajczyk",https://arxiv.org/abs/2603.27455
+3-left,Efficiently Reconstructing Dynamic Scenes One D4RT at a Time,"Chuhan Zhang, Guillaume Le Moing, Skanda Koppula, Ignacio Rocco, Liliane Momeni, Junyu Xie, Shuyang Sun, Rahul Sukthankar, Joëlle K. Barral, Raia Hadsell, Zoubin Ghahramani, Andrew Zisserman, Junlin Zhang, Mehdi S. M. Sajjadi",https://arxiv.org/abs/2512.08924
+3-right,Seeing without Pixels: Perception from Camera Trajectories,"Zihui Xue, Kristen Grauman, Dima Damen, Andrew Zisserman, Tengda Han",https://arxiv.org/abs/2511.21681
+4-left,Next-Embedding Prediction Makes Strong Vision Learners,"Sihan Xu, Ziqiao Ma, Wenhao Chai, Xuweiyi Chen, Weiyang Jin, Joyce Chai, Saining Xie, Stella X. Yu",https://arxiv.org/abs/2512.16922
+4-right,4D-RGPT: Toward Region-level 4D Understanding via Perceptual Distillation,"Chiao-An Yang, Ryo Hachiuma, Sifei Liu, Subhashree Radhakrishnan, Raymond A. Yeh, Yu-Chiang Frank Wang, Min-Hung Chen",https://arxiv.org/abs/2512.17012
+5-left,Steerable Visual Representations,"Jona Ruthardt, Manu Gaur, Deva Ramanan, Makarand Tapaswi, Yuki M. Asano",https://arxiv.org/abs/2604.02327
+5-right,VGGT-Ω,"Jianyuan Wang, Minghao Chen, Shangzhan Zhang, Nikita Karaev, Johannes Schönberger, Patrick Labatut, Piotr Bojanowski, David Novotny, Andrea Vedaldi, Christian Rupprecht",https://arxiv.org/abs/2605.15195
+6-left,A Frame is Worth One Token: Efficient Generative World Modeling with Delta Tokens,"Tommie Kerssies, Gabriele Berton, Ju He, Qihang Yu, Wufei Ma, Daan de Geus, Gijs Dubbelman, Liang-Chieh Chen",https://arxiv.org/abs/2604.04913
+6-right,Visual General Intelligence: Vision Research Toward the AGI Era,Hirokatsu Kataoka et al.,
+7-left,TBD,Kohsuke Ide et al.,
+7-right,COG: Confidence-aware Optimal Geometric Correspondence for Unsupervised Single-reference Novel Object Pose Estimation,"Yuchen Che, Jingtu Wu, Hao Zheng, Asako Kanezaki",https://arxiv.org/abs/2603.00493
+8-left,Towards Structured Recognition and Generation of Human-Object Interactions,"Takuma Yagi, Kohei Torimi, Jyun-Ting Song, Kris Kitani",
+8-right,BabyVLM-V2: Toward Developmentally Grounded Pretraining and Benchmarking of Vision Foundation Models,"Shengao Wang, Wenqi Wang, Zecheng Wang, Max Whitton, Michael Wakeham, Arjun Chandra, Joey Huang, Pengyue Zhu, Helen Chen, David Li, Jeffrey Li, Shawn Li, Andrew Zagula, Amy Zhao, Andrew Zhu, Sayaka Nakamura, Yuki Yamamoto, Jerry Jun Yokono, Aaron Mueller, Bryan A. Plummer, Kate Saenko, Venkatesh Saligrama, Boqing Gong",https://arxiv.org/abs/2512.10932
+9,Planning in 8 Tokens: A Compact Discrete Tokenizer for Latent World Model,"Dongwon Kim, Gawon Seo, Jinsung Lee, Minsu Cho, Suha Kwak",https://arxiv.org/abs/2603.05438
+10,E-RayZer: Self-supervised 3D Reconstruction as Spatial Visual Pre-training,"Qitao Zhao, Hao Tan, Qianqian Wang, Sai Bi, Kai Zhang, Kalyan Sunkavalli, Shubham Tulsiani, Hanwen Jiang",https://arxiv.org/abs/2512.10950

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -311,6 +311,67 @@ function Home() {
         </div>
       </section>
 
+      {/* Invited Poster Session */}
+      {programData.invitedPosters && programData.invitedPosters.length > 0 && (
+        <section id="invited-posters" className="space-y-6">
+          <div className="space-y-2">
+            <h2 className="text-2xl sm:text-3xl tracking-tighter">
+              Invited Poster Session
+            </h2>
+          </div>
+          <p>
+            Posters must be 42&quot; x 21&quot; (Width x Height, aspect ratio
+            2:1, landscape format). All posters will be displayed in{" "}
+            <span className="font-semibold">Exhibit Hall A</span>. Poster boards
+            will be available during your assigned session time. You may use the
+            official{" "}
+            <a
+              href="https://drive.google.com/drive/folders/1oaXlMOJzWMYUiFBImMepKsZcoicpks8Z"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-primary"
+            >
+              CVPR logos and poster templates
+            </a>
+            .
+          </p>
+          <div className="relative border-border space-y-8">
+            {programData.invitedPosters.map((paper, index) => (
+              <div key={index} className="relative">
+                <div className="space-y-1">
+                  {paper.posterBoard && (
+                    <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary w-fit">
+                      Board {paper.posterBoard}
+                    </span>
+                  )}
+                  <h3 className="font-semibold">{paper.title}</h3>
+                  <p className="text-sm">{paper.authors}</p>
+                  {paper.url && (
+                    <div className="mt-1">
+                      <Button
+                        variant="link"
+                        size="sm"
+                        className="h-auto p-0 text-xs"
+                        asChild
+                      >
+                        <a
+                          href={paper.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <ExternalLink className="mr-1 h-3 w-3" />
+                          Paper
+                        </a>
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* Organizers */}
       <section id="organizers" className="space-y-6">
         <div className="space-y-2">

--- a/src/data/home.json
+++ b/src/data/home.json
@@ -36,6 +36,11 @@
   ],
   "latestNews": [
     {
+      "title": "Invited Poster Session updated",
+      "date": "June 2, 2026",
+      "content": "The Invited Poster Session information has been updated. Presenters are kindly asked to display their posters at the assigned Poster Board. Please check the Invited Poster Session section for details."
+    },
+    {
       "title": "Workshop page open",
       "date": "December 21, 2025",
       "content": "We are excited to announce that our workshop page is now live. We will continue to add information, so please check back regularly for updates."

--- a/src/data/program.json
+++ b/src/data/program.json
@@ -262,6 +262,113 @@
       }
     ]
   },
+  "invitedPosters": [
+    {
+      "posterBoard": "1-left",
+      "title": "Theory of Space: Can Foundation Models Construct Spatial Beliefs through Active Exploration?",
+      "authors": "Pingyue Zhang, Zihan Huang, Yue Wang, Jieyu Zhang, Letian Xue, Zihan Wang, Qineng Wang, Keshigeyan Chandrasegaran, Ruohan Zhang, Yejin Choi, Ranjay Krishna, Jiajun Wu, Li Fei-Fei, Manling Li",
+      "url": "https://arxiv.org/abs/2602.07055"
+    },
+    {
+      "posterBoard": "1-right",
+      "title": "Unique Lives, Shared World: Learning from Single-Life Videos",
+      "authors": "Tengda Han, Sayna Ebrahimi, Dilara Gokay, Li Yang Ku, Maks Ovsjanikov, Iva Babukova, Daniel Zoran, Viorica Patraucean, Joao Carreira, Andrew Zisserman, Dima Damen",
+      "url": "https://arxiv.org/abs/2512.04085"
+    },
+    {
+      "posterBoard": "2-left",
+      "title": "Learning to See Through a Baby's Eyes: Early Visual Diets Enable Robust Visual Intelligence in Humans and Machines",
+      "authors": "Yusen Cai, Qing Lin, Bhargava Satya Nunna, Mengmi Zhang",
+      "url": "https://arxiv.org/abs/2511.14440"
+    },
+    {
+      "posterBoard": "2-right",
+      "title": "From None to All: Self-Supervised 3D Reconstruction via Novel View Synthesis",
+      "authors": "Ranran Huang, Weixun Luo, Ye Mao, Krystian Mikolajczyk",
+      "url": "https://arxiv.org/abs/2603.27455"
+    },
+    {
+      "posterBoard": "3-left",
+      "title": "Efficiently Reconstructing Dynamic Scenes One D4RT at a Time",
+      "authors": "Chuhan Zhang, Guillaume Le Moing, Skanda Koppula, Ignacio Rocco, Liliane Momeni, Junyu Xie, Shuyang Sun, Rahul Sukthankar, Joëlle K. Barral, Raia Hadsell, Zoubin Ghahramani, Andrew Zisserman, Junlin Zhang, Mehdi S. M. Sajjadi",
+      "url": "https://arxiv.org/abs/2512.08924"
+    },
+    {
+      "posterBoard": "3-right",
+      "title": "Seeing without Pixels: Perception from Camera Trajectories",
+      "authors": "Zihui Xue, Kristen Grauman, Dima Damen, Andrew Zisserman, Tengda Han",
+      "url": "https://arxiv.org/abs/2511.21681"
+    },
+    {
+      "posterBoard": "4-left",
+      "title": "Next-Embedding Prediction Makes Strong Vision Learners",
+      "authors": "Sihan Xu, Ziqiao Ma, Wenhao Chai, Xuweiyi Chen, Weiyang Jin, Joyce Chai, Saining Xie, Stella X. Yu",
+      "url": "https://arxiv.org/abs/2512.16922"
+    },
+    {
+      "posterBoard": "4-right",
+      "title": "4D-RGPT: Toward Region-level 4D Understanding via Perceptual Distillation",
+      "authors": "Chiao-An Yang, Ryo Hachiuma, Sifei Liu, Subhashree Radhakrishnan, Raymond A. Yeh, Yu-Chiang Frank Wang, Min-Hung Chen",
+      "url": "https://arxiv.org/abs/2512.17012"
+    },
+    {
+      "posterBoard": "5-left",
+      "title": "Steerable Visual Representations",
+      "authors": "Jona Ruthardt, Manu Gaur, Deva Ramanan, Makarand Tapaswi, Yuki M. Asano",
+      "url": "https://arxiv.org/abs/2604.02327"
+    },
+    {
+      "posterBoard": "5-right",
+      "title": "VGGT-Ω",
+      "authors": "Jianyuan Wang, Minghao Chen, Shangzhan Zhang, Nikita Karaev, Johannes Schönberger, Patrick Labatut, Piotr Bojanowski, David Novotny, Andrea Vedaldi, Christian Rupprecht",
+      "url": "https://arxiv.org/abs/2605.15195"
+    },
+    {
+      "posterBoard": "6-left",
+      "title": "A Frame is Worth One Token: Efficient Generative World Modeling with Delta Tokens",
+      "authors": "Tommie Kerssies, Gabriele Berton, Ju He, Qihang Yu, Wufei Ma, Daan de Geus, Gijs Dubbelman, Liang-Chieh Chen",
+      "url": "https://arxiv.org/abs/2604.04913"
+    },
+    {
+      "posterBoard": "6-right",
+      "title": "Visual General Intelligence: Vision Research Toward the AGI Era",
+      "authors": "Hirokatsu Kataoka et al."
+    },
+    {
+      "posterBoard": "7-left",
+      "title": "TBD",
+      "authors": "Kohsuke Ide et al."
+    },
+    {
+      "posterBoard": "7-right",
+      "title": "COG: Confidence-aware Optimal Geometric Correspondence for Unsupervised Single-reference Novel Object Pose Estimation",
+      "authors": "Yuchen Che, Jingtu Wu, Hao Zheng, Asako Kanezaki",
+      "url": "https://arxiv.org/abs/2603.00493"
+    },
+    {
+      "posterBoard": "8-left",
+      "title": "Towards Structured Recognition and Generation of Human-Object Interactions",
+      "authors": "Takuma Yagi, Kohei Torimi, Jyun-Ting Song, Kris Kitani"
+    },
+    {
+      "posterBoard": "8-right",
+      "title": "BabyVLM-V2: Toward Developmentally Grounded Pretraining and Benchmarking of Vision Foundation Models",
+      "authors": "Shengao Wang, Wenqi Wang, Zecheng Wang, Max Whitton, Michael Wakeham, Arjun Chandra, Joey Huang, Pengyue Zhu, Helen Chen, David Li, Jeffrey Li, Shawn Li, Andrew Zagula, Amy Zhao, Andrew Zhu, Sayaka Nakamura, Yuki Yamamoto, Jerry Jun Yokono, Aaron Mueller, Bryan A. Plummer, Kate Saenko, Venkatesh Saligrama, Boqing Gong",
+      "url": "https://arxiv.org/abs/2512.10932"
+    },
+    {
+      "posterBoard": "9",
+      "title": "Planning in 8 Tokens: A Compact Discrete Tokenizer for Latent World Model",
+      "authors": "Dongwon Kim, Gawon Seo, Jinsung Lee, Minsu Cho, Suha Kwak",
+      "url": "https://arxiv.org/abs/2603.05438"
+    },
+    {
+      "posterBoard": "10",
+      "title": "E-RayZer: Self-supervised 3D Reconstruction as Spatial Visual Pre-training",
+      "authors": "Qitao Zhao, Hao Tan, Qianqian Wang, Sai Bi, Kai Zhang, Kalyan Sunkavalli, Shubham Tulsiani, Hanwen Jiang",
+      "url": "https://arxiv.org/abs/2512.10950"
+    }
+  ],
   "panelDiscussion": {
     "title": "Panel: Challenges and Opportunities in Machine Learning",
     "time": "October 16, 2025, 13:15 - 14:45",


### PR DESCRIPTION
## Summary
Add Invited Poster Session section to the VGI workshop website with poster board assignments.

## Changes
- Added `invitedPosters` data to `program.json` with 17 poster entries
- Added Invited Poster Session section to Home page displaying:
  - Poster board assignments as colored badges above titles
  - Author information
  - Links to papers (when available)
  - Reference to CVPR poster templates
- Added latest news entry announcing the Invited Poster Session update
- Added `docs/posters.csv` as the source data file

## Poster Display
- Posters are displayed with board numbers in colored badges for better visibility
- Each poster shows title, authors, and paper link (if available)
- Information about poster format and location included

🤖 Generated with [Claude Code](https://claude.com/claude-code)