### PR TITLE
feat: update Alexei A. Efros talk title

### DIFF
--- a/src/data/program.json
+++ b/src/data/program.json
@@ -54,7 +54,7 @@
       "name": "Alexei A. Efros",
       "affiliation": "University of California, Berkeley",
       "photo": "/program/alexei.efros-512x512.jpg",
-      "title": "",
+      "title": "Surface Data vs. Deep Data: learning intelligence from the buttom up",
       "bio": "",
       "website": "https://people.eecs.berkeley.edu/~efros/"
     },

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -93,7 +93,7 @@
           "time": "14:10 - 14:50",
           "session": "Invited Talk 7",
           "presenter": "Alexei A. Efros",
-          "title": "",
+          "title": "Surface Data vs. Deep Data: learning intelligence from the buttom up",
           "slides": ""
         },
         {


### PR DESCRIPTION
## Summary
- Updated Alexei A. Efros (Alyosha) talk title to "Surface Data vs. Deep Data: learning intelligence from the buttom up"

## Changes
- Updated `src/data/program.json` with the new talk title
- Updated `src/data/schedule.json` with the new talk title

## Test plan
- [x] Verify the talk title appears correctly in the program page
- [x] Verify the talk title appears correctly in the schedule page

🤖 Generated with [Claude Code](https://claude.com/claude-code)