### PR TITLE
feat: add workshop conclusion news

### DIFF
--- a/src/data/home.json
+++ b/src/data/home.json
@@ -36,6 +36,11 @@
   ],
   "latestNews": [
     {
+      "title": "Workshop successfully concluded",
+      "date": "June 3, 2026",
+      "content": "The workshop has been successfully concluded with great participation from many attendees. We sincerely thank all participants, speakers, and organizers for making this event a success."
+    },
+    {
       "title": "Invited Poster Session updated",
       "date": "June 2, 2026",
       "content": "The Invited Poster Session information has been updated. Presenters are kindly asked to display their posters at the assigned Poster Board. Please check the Invited Poster Session section for details."


### PR DESCRIPTION
## Summary
- Add news item announcing the successful conclusion of the workshop on June 3, 2026
- News expresses gratitude to participants, speakers, and organizers

## Test plan
- [x] Verify the news appears correctly on the homepage
- [x] Confirm the date is displayed as June 3, 2026
- [x] Check that the news item appears at the top of the latest news section

🤖 Generated with [Claude Code](https://claude.com/claude-code)