### PR TITLE
feat: redesign workshop program table and add speaker slides

### DIFF
--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -5,6 +5,7 @@ import {
   ExternalLink,
   FileText,
   Info,
+  Video,
 } from "lucide-react";
 import { SiSlack } from "react-icons/si";
 import { Link, useLocation } from "react-router";
@@ -221,8 +222,6 @@ function Home() {
               <TableRow>
                 <TableHead className="w-[150px]">Time</TableHead>
                 <TableHead>Session</TableHead>
-                <TableHead>Presenter</TableHead>
-                <TableHead className="hidden md:table-cell w-[140px]"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -231,26 +230,46 @@ function Home() {
                   <TableCell className="font-medium">{item.time}</TableCell>
                   <TableCell>
                     <div className="space-y-1">
-                      <div>{item.session}</div>
+                      {item.presenter ? (
+                        <>
+                          <div className="font-semibold">{item.presenter}</div>
+                          <div className="text-sm text-muted-foreground">
+                            {item.session}
+                          </div>
+                        </>
+                      ) : (
+                        <div className="text-sm text-muted-foreground">
+                          {item.session}
+                        </div>
+                      )}
                       {item.title && (
                         <div className="text-sm text-muted-foreground italic">
                           {item.title}
                         </div>
                       )}
+                      {item.resources && item.resources.length > 0 && (
+                        <div className="flex items-center gap-3 pt-1">
+                          {item.resources.map((resource, rIndex) => (
+                            <a
+                              key={rIndex}
+                              href={resource.url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="inline-flex items-center gap-1 text-xs text-primary hover:text-primary/80"
+                            >
+                              {resource.type === "slides" && (
+                                <FileText className="h-3.5 w-3.5" />
+                              )}
+                              {resource.type === "video" && (
+                                <Video className="h-3.5 w-3.5" />
+                              )}
+                              {resource.type === "slides" && "Slides"}
+                              {resource.type === "video" && "Video"}
+                            </a>
+                          ))}
+                        </div>
+                      )}
                     </div>
-                  </TableCell>
-                  <TableCell>{item.presenter || ""}</TableCell>
-                  <TableCell className="hidden md:table-cell">
-                    {item.slides ? (
-                      <Button variant="ghost" size="sm" asChild>
-                        <a href={item.slides} target="_blank" rel="noreferrer">
-                          <FileText className="mr-2 h-4 w-4" />
-                          Slides
-                        </a>
-                      </Button>
-                    ) : (
-                      <span className="text-muted-foreground text-sm"></span>
-                    )}
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -33,93 +33,123 @@
           "session": "Organizer Talk & Opening Remarks",
           "presenter": "Hirokatsu Kataoka",
           "title": "Visual General Intelligence: Vision Research Toward the AGI Era",
-          "slides": ""
+          "resources": [
+            {
+              "type": "slides",
+              "url": "https://cdn.limitlab.xyz/cvpr2026/s/cvpr2026-vgi-workshop-opening-remarks-hirokatsu-kataoka_latest-en.pdf"
+            }
+          ]
         },
         {
           "time": "08:40 - 09:20",
           "session": "Invited Talk 1",
           "presenter": "Robert Geirhos",
           "title": "Are generative video models the path towards solving visual intelligence?",
-          "slides": ""
+          "resources": [
+            {
+              "type": "slides",
+              "url": "https://cdn.limitlab.xyz/cvpr2026/s/cvpr2026-vgi-workshop-invited-talk-robert-geirhos_latest-en.pdf"
+            }
+          ]
         },
         {
           "time": "09:20 - 10:00",
           "session": "Invited Talk 2",
           "presenter": "Aditi Raghunathan",
           "title": "How to get creativity in AI",
-          "slides": ""
+          "resources": [
+            {
+              "type": "slides",
+              "url": "https://cdn.limitlab.xyz/cvpr2026/s/cvpr2026-vgi-workshop-invited-talk-aditi-raghunathan_latest-en.pdf"
+            }
+          ]
         },
         {
           "time": "10:00 - 10:40",
           "session": "Invited Talk 3",
           "presenter": "Matt Deitke",
           "title": "",
-          "slides": ""
+          "resources": []
         },
         {
           "time": "10:40 - 11:00",
           "session": "Short Break",
           "presenter": "",
-          "slides": ""
+          "resources": []
         },
         {
           "time": "11:00 - 11:40",
           "session": "Invited Talk 4",
           "presenter": "Kristen Grauman",
           "title": "Beyond Words: Capturing the Physical Nature of Human Activity in Video",
-          "slides": ""
+          "resources": []
         },
         {
           "time": "11:40 - 12:20",
           "session": "Invited Talk 5",
           "presenter": "Yuki M. Asano",
           "title": "Learning from moving, Generalising from speaking",
-          "slides": ""
+          "resources": []
         },
         {
           "time": "12:20 - 13:30",
           "session": "Lunch break / poster session (invite-only)",
           "presenter": "",
-          "slides": ""
+          "resources": []
         },
         {
           "time": "13:30 - 14:10",
           "session": "Invited Talk 6",
           "presenter": "Andrea Vedaldi",
           "title": "Building a 3D Foundation for Spatial AI",
-          "slides": ""
+          "resources": [
+            {
+              "type": "slides",
+              "url": "https://cdn.limitlab.xyz/cvpr2026/s/cvpr2026-vgi-workshop-invited-talk-andrea-vedaldi_latest-en.pdf"
+            }
+          ]
         },
         {
           "time": "14:10 - 14:50",
           "session": "Invited Talk 7",
           "presenter": "Alexei A. Efros",
           "title": "Surface Data vs. Deep Data: learning intelligence from the buttom up",
-          "slides": ""
+          "resources": []
         },
         {
           "time": "14:50 - 15:10",
           "session": "Coffee break",
           "presenter": "",
-          "slides": ""
+          "resources": []
         },
         {
           "time": "15:10 - 15:50",
           "session": "Invited Talk 8",
           "presenter": "Alex Kendall",
           "title": "Frontier challenges to bring general purpose driving AI to 10M cars",
-          "slides": ""
+          "resources": [
+            {
+              "type": "slides",
+              "url": "https://cdn.limitlab.xyz/cvpr2026/s/cvpr2026-vgi-workshop-invited-talk-alex-kendall_latest-en.pdf"
+            }
+          ]
         },
         {
           "time": "15:50 - 16:00",
           "session": "Closing remarks",
           "presenter": "Yoshihiro Fukuhara",
-          "slides": ""
+          "resources": [
+            {
+              "type": "slides",
+              "url": "https://cdn.limitlab.xyz/cvpr2026/s/cvpr2026-vgi-workshop-closing-remarks-yoshihiro-fukuhara_latest-en.pdf"
+            }
+          ]
         },
         {
           "time": "16:00 - 16:50",
           "session": "Discussion time",
           "presenter": "",
-          "slides": ""
+          "resources": []
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Redesign Workshop Program table to BigMAC style: presenter name displayed prominently (bold), session type and title shown below in muted text
- Replace `slides` field with `resources` array in schedule data to support multiple resource types (slides, video, etc.)
- Add inline labeled resource links below each session's content (works on mobile too)
- Add slides links for 6 speakers: Hirokatsu Kataoka, Robert Geirhos, Aditi Raghunathan, Andrea Vedaldi, Alex Kendall, Yoshihiro Fukuhara

## Test plan
- [x] Verify the Workshop Program table displays presenter names in bold with session type below
- [x] Verify slides links appear as labeled "Slides" links below session content
- [x] Verify rows without resources (breaks, etc.) render cleanly
- [x] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)