### PR TITLE
feat: add Yuki Asano presentation slides

### DIFF
--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -89,7 +89,12 @@
           "session": "Invited Talk 5",
           "presenter": "Yuki M. Asano",
           "title": "Learning from moving, Generalising from speaking",
-          "resources": []
+          "resources": [
+            {
+              "type": "slides",
+              "url": "https://cdn.limitlab.xyz/cvpr2026/s/cvpr2026-vgi-workshop-invited-talk-yuki-asano_latest-en.pdf"
+            }
+          ]
         },
         {
           "time": "12:20 - 13:30",


### PR DESCRIPTION
## Summary
- Add slides URL for Yuki M. Asano's invited talk to the workshop program

## Changes
- Updated `schedule.json` to include the slides resource for Yuki M. Asano's presentation "Learning from moving, Generalising from speaking"

## Test plan
- [ ] Verify that the slides link appears in the workshop program table
- [ ] Confirm the link opens the correct PDF file

🤖 Generated with [Claude Code](https://claude.com/claude-code)