### PR TITLE
feat: announce the VGI white paper on the workshop page

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://cvpr2026-vgi-workshop.limitlab.xyz/</loc>
-    <lastmod>2026-12-21</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -1,5 +1,7 @@
 import {
   Calendar,
+  Check,
+  Copy,
   Mail,
   MapPin,
   ExternalLink,
@@ -8,7 +10,7 @@ import {
 } from "lucide-react";
 import { SiSlack } from "react-icons/si";
 import { Link, useLocation } from "react-router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import {
   Table,
@@ -37,6 +39,7 @@ import technicalSupportersData from "../../data/technicalSupporters.json";
 import supportersData from "../../data/supporters.json";
 import contactData from "../../data/contact.json";
 import callForPapersData from "../../data/callForPapers.json";
+import whitePaperData from "../../data/whitePaper.json";
 import type { Route } from "./+types/Home";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { buildMeta } from "@/lib/seo";
@@ -46,13 +49,18 @@ export const meta: Route.MetaFunction = () =>
     title:
       "VGI Workshop @ CVPR 2026 | Visual General Intelligence -Vision Research Toward the AGI Era-",
     description:
-      "VGI Workshop at CVPR 2026 spotlights resource-efficient representation learning. Join us on October 19 in Honolulu for keynotes, paper presentations, and community updates.",
+      "VGI Workshop at CVPR 2026 asked how vision research should be conducted in the AGI era. Read the resulting white paper on arXiv, together with the full program, invited talks, and speaker slides.",
     path: "/",
-    keywords: ["CVPR workshop 2026", "visual general intelligence"],
+    keywords: [
+      "CVPR workshop 2026",
+      "visual general intelligence",
+      "VGI white paper",
+    ],
   });
 
 function Home() {
   const location = useLocation();
+  const [bibtexCopied, setBibtexCopied] = useState(false);
 
   useEffect(() => {
     if (!location.hash) return;
@@ -60,6 +68,20 @@ function Home() {
     const element = document.querySelector(location.hash);
     element?.scrollIntoView({ behavior: "smooth" });
   }, [location.hash]);
+
+  useEffect(() => {
+    if (!bibtexCopied) return;
+
+    const timer = setTimeout(() => setBibtexCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [bibtexCopied]);
+
+  const handleCopyBibtex = () => {
+    navigator.clipboard
+      .writeText(whitePaperData.bibtex)
+      .then(() => setBibtexCopied(true))
+      .catch(() => setBibtexCopied(false));
+  };
 
   return (
     <main className="container px-6 py-8 space-y-16 xl:w-6xl">
@@ -126,6 +148,20 @@ function Home() {
             </Button>
           </div>
         </div>
+
+        {/* White Paper callout */}
+        <div className="relative z-10 mx-auto mt-10 w-full max-w-4xl border-t pt-6">
+          <p className="text-sm text-muted-foreground">
+            Following the workshop, our white paper{" "}
+            <Link
+              to="/#white-paper"
+              className="font-medium text-foreground underline hover:text-primary"
+            >
+              {whitePaperData.title}
+            </Link>{" "}
+            is now available on arXiv.
+          </p>
+        </div>
       </section>
 
       {/* Latest News Section */}
@@ -143,8 +179,93 @@ function Home() {
                 </div>
               </div>
               <p className="mt-2">{news.content}</p>
+              {news.links && news.links.length > 0 && (
+                <div className="mt-2 flex flex-wrap items-center gap-3">
+                  {news.links.map((link, linkIndex) => (
+                    <Button
+                      key={linkIndex}
+                      variant="link"
+                      size="sm"
+                      className="h-auto p-0 text-xs"
+                      asChild
+                    >
+                      <a
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <ExternalLink className="mr-1 h-3 w-3" />
+                        {link.label}
+                      </a>
+                    </Button>
+                  ))}
+                </div>
+              )}
             </div>
           ))}
+        </div>
+      </section>
+
+      {/* White Paper Section */}
+      <section id="white-paper" className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-2xl sm:text-3xl tracking-tighter">White Paper</h2>
+          <p>{whitePaperData.description}</p>
+        </div>
+        <div className="relative overflow-hidden rounded-3xl border bg-gradient-to-br from-primary/10 via-background to-background px-6 py-10 shadow-lg sm:px-10">
+          <div className="pointer-events-none absolute inset-0 -z-10">
+            <div className="h-full w-full bg-gradient-to-b from-primary/20 via-transparent to-transparent dark:from-primary/30" />
+          </div>
+          <div className="relative z-10 space-y-5">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary w-fit">
+                {whitePaperData.badge}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {whitePaperData.date}
+              </span>
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-2xl tracking-tighter sm:text-3xl">
+                {whitePaperData.title}
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                {whitePaperData.authors.join(", ")}
+              </p>
+            </div>
+            <p>{whitePaperData.abstract}</p>
+            <div className="flex flex-wrap gap-3">
+              {whitePaperData.links.map((link, index) => (
+                <Button
+                  key={index}
+                  variant="outline"
+                  size="sm"
+                  className="flex gap-2"
+                  asChild
+                >
+                  <a href={link.url} target="_blank" rel="noreferrer">
+                    {link.label} <ExternalLink className="h-4 w-4" />
+                  </a>
+                </Button>
+              ))}
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex gap-2"
+                onClick={handleCopyBibtex}
+              >
+                {bibtexCopied ? (
+                  <>
+                    Copied <Check className="h-4 w-4" />
+                  </>
+                ) : (
+                  <>
+                    BibTeX <Copy className="h-4 w-4" />
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -123,6 +123,12 @@ export function Footer() {
             Home
           </Link>
           <Link
+            to="/#white-paper"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            White Paper
+          </Link>
+          <Link
             to="/#program"
             className="text-sm text-muted-foreground hover:text-foreground"
           >

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -15,6 +15,7 @@ import { Sheet, SheetContent, SheetTrigger, SheetClose } from "./ui/sheet";
 
 const navItems = [
   { name: "Home", path: "/" },
+  { name: "White Paper", path: "/#white-paper" },
   { name: "Program", path: "/#program" },
   { name: "Speakers", path: "/#speakers" },
   { name: "Organizers", path: "/#organizers" },

--- a/src/data/home.json
+++ b/src/data/home.json
@@ -36,19 +36,33 @@
   ],
   "latestNews": [
     {
+      "title": "White paper released on arXiv",
+      "date": "August 26, 2026",
+      "content": "The discussion started at the workshop has been continued by the organizers and invited speakers, and is now published as a white paper, \"Visual General Intelligence: A White Paper\", co-authored by 21 contributors. It is available on arXiv.",
+      "links": [
+        {
+          "label": "Read the white paper",
+          "url": "https://arxiv.org/abs/2608.25924"
+        }
+      ]
+    },
+    {
       "title": "Workshop successfully concluded",
       "date": "June 3, 2026",
-      "content": "The workshop has been successfully concluded with great participation from many attendees. We sincerely thank all participants, speakers, and organizers for making this event a success."
+      "content": "The workshop has been successfully concluded with great participation from many attendees. We sincerely thank all participants, speakers, and organizers for making this event a success.",
+      "links": []
     },
     {
       "title": "Invited Poster Session updated",
       "date": "June 2, 2026",
-      "content": "The Invited Poster Session information has been updated. Presenters are kindly asked to display their posters at the assigned Poster Board. Please check the Invited Poster Session section for details."
+      "content": "The Invited Poster Session information has been updated. Presenters are kindly asked to display their posters at the assigned Poster Board. Please check the Invited Poster Session section for details.",
+      "links": []
     },
     {
       "title": "Workshop page open",
       "date": "December 21, 2025",
-      "content": "We are excited to announce that our workshop page is now live. We will continue to add information, so please check back regularly for updates."
+      "content": "We are excited to announce that our workshop page is now live. We will continue to add information, so please check back regularly for updates.",
+      "links": []
     }
   ]
 }

--- a/src/data/whitePaper.json
+++ b/src/data/whitePaper.json
@@ -1,0 +1,41 @@
+{
+  "badge": "arXiv:2608.25924",
+  "title": "Visual General Intelligence: A White Paper",
+  "date": "August 26, 2026",
+  "authors": [
+    "Hirokatsu Kataoka",
+    "Yoshihiro Fukuhara",
+    "Yonglong Tian",
+    "Shangzhe Wu",
+    "Oishi Deb",
+    "Ryousuke Yamada",
+    "Christian Rupprecht",
+    "Jianyuan Wang",
+    "Kohsuke Ide",
+    "Koichi Namekata",
+    "Xianzheng Ma",
+    "Yiming Chen",
+    "Robert Geirhos",
+    "Aditi Raghunathan",
+    "Yuki M. Asano",
+    "Deva Ramanan",
+    "David Fouhey",
+    "Andrew J. Davison",
+    "Yilun Du",
+    "Jiajun Wu",
+    "Zhuang Liu"
+  ],
+  "description": "The discussion started at the VGI Workshop has been continued by the organizers and invited speakers, and is now published as a white paper on arXiv.",
+  "abstract": "This paper reconsiders intelligence from a vision-centered perspective and examines whether intelligence emerging from visual experience and learning may provide a pathway toward AGI. In the language domain, beginning with the introduction of the Transformer architecture, the GPT series has demonstrated transfer to unseen tasks through autoregressive language modeling on web-scale text combined with aggressive scaling. This raises a natural question, namely, what capabilities and forms of intelligence can emerge from visual modalities such as images, videos, and geometry? In this paper, we discuss whether visual intelligence can serve as a pathway toward AGI, referred to in this paper as visual general intelligence (VGI), by bringing together contributors from diverse standpoints and affiliations. Our aim is not to offer a single definition of visual intelligence, but to clarify the principles that computer vision should pursue in the AGI era, the visual input modalities, the benchmarks, the learning paradigms, and the relationship between vision, when taken as the core, and other modalities such as language.",
+  "links": [
+    {
+      "label": "arXiv",
+      "url": "https://arxiv.org/abs/2608.25924"
+    },
+    {
+      "label": "PDF",
+      "url": "https://arxiv.org/pdf/2608.25924"
+    }
+  ],
+  "bibtex": "@article{kataoka2026visual,\n  title   = {Visual General Intelligence: A White Paper},\n  author  = {Kataoka, Hirokatsu and Fukuhara, Yoshihiro and Tian, Yonglong and Wu, Shangzhe and Deb, Oishi and Yamada, Ryousuke and Rupprecht, Christian and Wang, Jianyuan and Ide, Kohsuke and Namekata, Koichi and Ma, Xianzheng and Chen, Yiming and Geirhos, Robert and Raghunathan, Aditi and Asano, Yuki M. and Ramanan, Deva and Fouhey, David and Davison, Andrew J. and Du, Yilun and Wu, Jiajun and Liu, Zhuang},\n  journal = {arXiv preprint arXiv:2608.25924},\n  year    = {2026}\n}\n"
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -6,7 +6,7 @@ const DEFAULT_IMAGE_ALT =
   "VGI Workshop at CVPR 2026 wordmark on a dark gradient background";
 const SITE_NAME = "VGI Workshop @ CVPR 2026";
 const DEFAULT_DESCRIPTION =
-  "Official site for the CVPR 2026 Workshop on Visual General Intelligence: Vision Research Toward the AGI Era.";
+  "Official site for the CVPR 2026 Workshop on Visual General Intelligence: Vision Research Toward the AGI Era. The discussion continues in our white paper, now available on arXiv.";
 const DEFAULT_KEYWORDS = [
   "VGI Workshop",
   "CVPR 2026",
@@ -14,6 +14,8 @@ const DEFAULT_KEYWORDS = [
   "VGI",
   "AGI",
   "LIMIT Lab",
+  "Visual General Intelligence White Paper",
+  "arXiv 2608.25924",
 ];
 
 type SeoConfig = {


### PR DESCRIPTION
## Issue URL

<!-- Please paste url to issue here. -->

N/A

## Change overview

The discussion started at the workshop continued afterwards and was published as **"Visual General Intelligence: A White Paper"** ([arXiv:2608.25924](https://arxiv.org/abs/2608.25924)), co-authored by 21 contributors. This PR surfaces it on the workshop page.

**White Paper section** (new, `#white-paper`, placed between Latest News and About)
- Reuses the hero's gradient panel treatment (`rounded-3xl border bg-gradient-to-br from-primary/10 ...`) and the Poster Board badge style, so no new visual vocabulary is introduced.
- Shows the arXiv ID, title, all 21 authors, and the abstract verbatim from arXiv.
- Buttons: arXiv / PDF (`variant="outline" size="sm"` + `ExternalLink`, matching Speakers / Organizers / Sponsors) and a copy-to-clipboard BibTeX button.
- Content lives in the new `src/data/whitePaper.json`, following the existing data/view split.

**Hero**
- Announced with a single line under a `border-t` divider: *"Following the workshop, our white paper … is now available on arXiv."*
- Deliberately **not** a second button next to Check Program — side by side, the two read as parallel options and the relationship between the workshop and the paper is lost. The divider plus the "Following the workshop" wording frames it as an outcome instead. The link style (`underline hover:text-primary`) is the one already used in the Invited Poster section.

**Latest News**
- One entry added. This required extending the `latestNews` schema with an optional `links` array; the three existing entries get `links: []`, matching how `schedule.json` gives every item a `resources` array.

**Navigation**
- "White Paper" added to the header `navItems` and the footer Links list.

**Drive-by fixes** (both pre-existing, unrelated to the white paper)
- The meta description still advertised *"October 19 in Honolulu"* with LIMIT-era wording about resource-efficient representation learning, contradicting `home.json` (June 3, 2026, Colorado Convention Center).
- `sitemap.xml` had a `lastmod` of `2026-12-21`, a future date.

## How to test

```bash
yarn install
yarn dev
```

- Hero: the white paper line sits below the divider, and Check Program is the only button again.
- `#white-paper`: verify the panel renders in both light and dark mode, that arXiv / PDF open correctly, and that BibTeX shows a `Copied` state for ~2s and puts a valid entry on the clipboard.
- `#news`: the new entry's "Read the white paper" link works; the other three entries are unchanged.
- Header and footer "White Paper" links scroll to the section.

`yarn lint`, `yarn lint:types`, and `yarn build` all pass locally.

## Note for reviewers

Two things worth a look:

1. **SEO / OGP.** The site builds in SPA mode (`ssr: false`), so the prerendered `build/client/index.html` contains **only** `root.tsx`'s meta, i.e. the defaults in `src/lib/seo.ts` — the `meta` export in `Home.tsx` is applied client-side and never reaches crawlers or link unfurlers. I updated both, but `seo.ts` is the one that actually affects search results and social cards. Verify with `yarn build && grep -o '<meta[^>]*>' build/client/index.html`.
2. **Hero overlay.** The White Paper panel copies the hero's inner `-z-10` glow overlay for structural parity. Note that in the hero this overlay is likely a no-op already: the parent is `position: relative` without a `z-index`, so it establishes no stacking context and the overlay paints behind the panel's own background. Behaviour is identical to the hero either way, but if you want to address it, both should be fixed together (e.g. adding `isolate`).

The hero link points at the on-page `#white-paper` section rather than straight to arXiv, so readers land on the abstract and citation first. Happy to change it to link out directly if you prefer.